### PR TITLE
Initial setup of Poetry-based build and install scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,44 @@
-.idea/
+*.pyc
+
+# Packages
+*.egg
+!/tests/**/*.egg
+/*.egg-info
+/dist/*
+build
+_build
+.cache
+*.so
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+.pytest_cache
+
+.DS_Store
+.idea/*
+.python-version
+.vscode/*
+
+/test.py
+/test_*.*
+
+/setup.cfg
+MANIFEST.in
+/setup.py
+/docs/site/*
+/tests/fixtures/simple_project/setup.py
+/tests/fixtures/project_with_extras/setup.py
+.mypy_cache
+
+.venv
+/releases/*
+pip-wheel-metadata
+/poetry.toml
+
+# Application specific stuff
 *.iml
 keeplog.log

--- a/README.md
+++ b/README.md
@@ -31,21 +31,23 @@ Installation
 1. Create a [Google App Password](https://myaccount.google.com/apppasswords) for keeplog
 2. Create a config file `~/.keeplog/config` from [this template](config). Be sure to edit at least 
    `user=`, `pass=` and `file=`.
-3. Install dependencies via `pip3 install -r requirements.txt`.
-4. Optionally (but highly recommended), you may either regularly run `keeplog.py sync` as a cron, or `keeplog.py watch` 
+3. Install [Poetry](https://python-poetry.org) if you don't have it.
+4. Install the application via Poetry into a virtualenv: `poetry install`
+5. Optionally (but highly recommended), you may either regularly run `poetry run keeplog sync` as a cron, or `poetry run keeplog watch` 
    as a long running process, such as a systemd user service:
    
 ```
-$ vi ~/.config/systemd/user/keeplog.service
+$ cat > ~/.config/systemd/user/keeplog.service <<EOF
 [Unit]
 Description=Keeplog watch daemon
 
 [Service]
-ExecStart=/path/to/keeplog/keeplog.py watch
+ExecStart=poetry run keeplog watch
+WorkingDirectory=/path/to/keeplog
 
 [Install]
 WantedBy=default.target
-
+EOF
 $ systemctl enable --user keeplog
 $ systemctl start --user keeplog
 $ journalctl --user -f -u keeplog
@@ -55,13 +57,13 @@ Usage
 --
 keeplog has two commands:
 
-- `keeplog.py sync` synchronizes local file with Google Keep
-- `keeplog.py watch` monitors the local file for changes and syncs when changed
+- `keeplog sync` synchronizes local file with Google Keep
+- `keeplog watch` monitors the local file for changes and syncs when changed
 
 Manually (or via cron):
 
 ```
-$ ./keeplog.py sync
+$ poetry run keeplog sync
 2020-11-08 13:33:50,038 [INFO] Logging in with token
 2020-11-08 13:33:59,221 [INFO] Successfully logged in
 2020-11-08 13:33:59,221 [INFO] Comparing remote and local
@@ -73,7 +75,7 @@ $ ./keeplog.py sync
 Using file system monitoring:
 
 ```
-$ ./keeplog.py watch
+$ poetry run keeplog watch
 2020-11-08 21:55:23,901 [INFO] Watching local log file for changes
 2020-11-08 21:55:31,728 [INFO] File modified, triggering sync
 ...
@@ -87,4 +89,4 @@ Copyright & recognition
 Philipp C. Heckel, licensed under the [Apache 2.0 License](LICENSE).
 
 Thanks very much to [kiwiz](https://github.com/kiwiz) for his excellent [gkeepapi](https://github.com/kiwiz/gkeepapi),
-and to [chrisjbillington](https://github.com/chrisjbillington) for his wonderfully easy [inotify_simple](https://github.com/chrisjbillington/inotify_simple). 
+and to [chrisjbillington](https://github.com/chrisjbillington) for his wonderfully easy [inotify_simple](https://github.com/chrisjbillington/inotify_simple).

--- a/keeplog/__init__.py
+++ b/keeplog/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import hashlib
 import json
 import logging
@@ -352,7 +350,7 @@ def watch(args):
             time.sleep(config.watch_interval)
 
 
-if __name__ == '__main__':
+def run():
     parser = argparse.ArgumentParser(prog='keeplog',
                                      description="Two-way sync tool between a local file and Google Keep")
     subparsers = parser.add_subparsers()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "keeplog"
+version = "0.0.0"
+description = "Simple two-way synchronization tool to sync a local daily log with Google Keep"
+authors = ["Philipp C. Heckel <philipp.heckel@gmail.com>"]
+license = "Apache-2.0"
+readme = "README.md"
+homepage = "https://github.com/binwiederhier/keeplog"
+repository = "https://github.com/binwiederhier/keeplog"
+
+[tool.poetry.dependencies]
+python = "^3.6"
+gkeepapi = ">=0.13.1"
+inotify_simple = ">=1.3.5"
+
+[tool.poetry.scripts]
+keeplog = "keeplog:run"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-gkeepapi>=0.13.1
-inotify_simple>=1.3.5


### PR DESCRIPTION
This adapts the project to use Poetry for building and installing
scripts, which makes it much more straightforward to run either as
a virtualenv or to build and install as a package for Linux platforms
that support modern Python packaging (such as Fedora).

It should also set up the project for eventually submitting to PyPI.